### PR TITLE
[Fix] decodeHTMLEntity: Don't break if string is 'null'

### DIFF
--- a/dist/misc/decodeHtmlEntity.js
+++ b/dist/misc/decodeHtmlEntity.js
@@ -11,7 +11,9 @@ exports.default = decodeHtmlEntity;
  */
 
 function decodeHtmlEntity(str) {
-  return str.replace(/&#(\d+);/g, function (match, dec) {
-    return String.fromCharCode(dec);
-  });
+  if (str) {
+    return str.replace(/&#(\d+);/g, function (match, dec) {
+      return String.fromCharCode(dec);
+    });
+  }
 }

--- a/src/misc/decodeHtmlEntity.js
+++ b/src/misc/decodeHtmlEntity.js
@@ -5,7 +5,9 @@
  */
 
 export default function decodeHtmlEntity (str) {
-  return str.replace(/&#(\d+);/g, (match, dec) => {
-    return String.fromCharCode(dec)
-  })
+  if (str) {
+    return str.replace(/&#(\d+);/g, (match, dec) => {
+      return String.fromCharCode(dec)
+    })
+  }
 }


### PR DESCRIPTION
Whenever you have a new WordPress installation there is an example page and an example post.
In the API they have – if they are never saved again – a few properties undefined (null), which causes the vuecid helper -> encodeHTMLEntity to fail.

By adding an if clause this is resolved.

<img width="655" alt="image" src="https://user-images.githubusercontent.com/7059580/40056486-1ef8422c-587e-11e8-83bb-27a275942ed7.png">


