### PR TITLE
[Update] Export isWordPressPreview

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99,6 +99,12 @@ Object.defineProperty(exports, "verifyTrailingSlash", {
     return _verifyTrailingSlash.default;
   }
 });
+Object.defineProperty(exports, "isWordPressPreview", {
+  enumerable: true,
+  get: function get() {
+    return _isWordPressPreview.default;
+  }
+});
 
 var _cleanString = _interopRequireDefault(require("./misc/cleanString"));
 
@@ -131,5 +137,7 @@ var _removeTrailingSlash = _interopRequireDefault(require("./url/removeTrailingS
 var _verifyLeadingSlash = _interopRequireDefault(require("./url/verifyLeadingSlash"));
 
 var _verifyTrailingSlash = _interopRequireDefault(require("./url/verifyTrailingSlash"));
+
+var _isWordPressPreview = _interopRequireDefault(require("./wp/misc/isWordPressPreview"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/dist/index.js
+++ b/dist/index.js
@@ -105,6 +105,12 @@ Object.defineProperty(exports, "isWordPressPreview", {
     return _isWordPressPreview.default;
   }
 });
+Object.defineProperty(exports, "generateMetaInfo", {
+  enumerable: true,
+  get: function get() {
+    return _generateMetaInfo.default;
+  }
+});
 
 var _cleanString = _interopRequireDefault(require("./misc/cleanString"));
 
@@ -139,5 +145,7 @@ var _verifyLeadingSlash = _interopRequireDefault(require("./url/verifyLeadingSla
 var _verifyTrailingSlash = _interopRequireDefault(require("./url/verifyTrailingSlash"));
 
 var _isWordPressPreview = _interopRequireDefault(require("./wp/misc/isWordPressPreview"));
+
+var _generateMetaInfo = _interopRequireDefault(require("./wp/meta/generateMetaInfo"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import verifyTrailingSlash from './url/verifyTrailingSlash'
 
 // WP helpers
 import isWordPressPreview from './wp/misc/isWordPressPreview'
+import generateMetaInfo from './wp/meta/generateMetaInfo'
 
 
 export {
@@ -47,5 +48,6 @@ export {
   removeTrailingSlash,
   verifyLeadingSlash,
   verifyTrailingSlash,
-  isWordPressPreview
+  isWordPressPreview,
+  generateMetaInfo
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,10 @@ import removeTrailingSlash from './url/removeTrailingSlash'
 import verifyLeadingSlash from './url/verifyLeadingSlash'
 import verifyTrailingSlash from './url/verifyTrailingSlash'
 
+// WP helpers
+import isWordPressPreview from './wp/misc/isWordPressPreview'
+
+
 export {
   // Misc utilities
   cleanString,
@@ -42,5 +46,6 @@ export {
   removeLeadingSlash,
   removeTrailingSlash,
   verifyLeadingSlash,
-  verifyTrailingSlash
+  verifyTrailingSlash,
+  isWordPressPreview
 }


### PR DESCRIPTION
When updating to the newest helpers I expected breaking changes, but I don't see a reason for why `isWordPressPreview` is not exposed in the package.
I would still need this function and as it is available, I would like to export it as well....

Any thoughts of yours, or why this was removed in the first place?